### PR TITLE
Enable compilation on Debian 9 (Stretch)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.7)
 
 project(radiotray-ng VERSION 0.2.4 LANGUAGES CXX)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.7)
+cmake_minimum_required(VERSION 3.10)
 
 project(radiotray-ng VERSION 0.2.4 LANGUAGES CXX)
 

--- a/debian/CMakeLists.txt
+++ b/debian/CMakeLists.txt
@@ -23,7 +23,7 @@ endif()
 
 set(CPACK_DEBIAN_PACKAGE_PRIORITY     "optional")
 set(CPACK_DEBIAN_PACKAGE_MAINTAINER   "Edward G. Bruck <ed.bruck1@gmail.com>")
-set(CPACK_DEBIAN_PACKAGE_DEPENDS      "libc6, libbsd0, libcurl4, libjsoncpp1, libxdg-basedir1, libnotify4, python2.7, python-lxml, libglibmm-2.4-1v5, libboost-filesystem${BOOST_DEB_VERSION}, libboost-system${BOOST_DEB_VERSION}, libboost-log${BOOST_DEB_VERSION}, libboost-thread${BOOST_DEB_VERSION}, libboost-program-options${BOOST_DEB_VERSION}, libgstreamer1.0-0, libappindicator3-1, gstreamer1.0-plugins-good, gstreamer1.0-plugins-bad, gstreamer1.0-plugins-ugly, libwxgtk3.0-0v5")
+set(CPACK_DEBIAN_PACKAGE_DEPENDS      "libc6, libbsd0, libcurl3 | libcurl4, libjsoncpp1, libxdg-basedir1, libnotify4, python2.7, python-lxml, libglibmm-2.4-1v5, libboost-filesystem${BOOST_DEB_VERSION}, libboost-system${BOOST_DEB_VERSION}, libboost-log${BOOST_DEB_VERSION}, libboost-thread${BOOST_DEB_VERSION}, libboost-program-options${BOOST_DEB_VERSION}, libgstreamer1.0-0, libappindicator3-1, gstreamer1.0-plugins-good, gstreamer1.0-plugins-bad, gstreamer1.0-plugins-ugly, libwxgtk3.0-0v5")
 set(CPACK_GENERATOR                   "DEB")
 set(CPACK_PACKAGE_FILE_NAME            ${CPACK_PACKAGE_NAME}_${PROJECT_VERSION}_${CPACK_DEBIAN_PACKAGE_ARCHITECTURE})
 set(CPACK_DEBIAN_PACKAGE_CONTROL_EXTRA ${PROJECT_SOURCE_DIR}/debian/postinst;${PROJECT_SOURCE_DIR}/debian/postrm)

--- a/debian/CMakeLists.txt
+++ b/debian/CMakeLists.txt
@@ -23,14 +23,16 @@ endif()
 
 set(CPACK_DEBIAN_PACKAGE_PRIORITY     "optional")
 set(CPACK_DEBIAN_PACKAGE_MAINTAINER   "Edward G. Bruck <ed.bruck1@gmail.com>")
-set(CPACK_DEBIAN_PACKAGE_DEPENDS      "libc6, libbsd0, libcurl3 | libcurl4, libjsoncpp1, libxdg-basedir1, libnotify4, python2.7, python-lxml, libglibmm-2.4-1v5, libboost-filesystem${BOOST_DEB_VERSION}, libboost-system${BOOST_DEB_VERSION}, libboost-log${BOOST_DEB_VERSION}, libboost-thread${BOOST_DEB_VERSION}, libboost-program-options${BOOST_DEB_VERSION}, libgstreamer1.0-0, libappindicator3-1, gstreamer1.0-plugins-good, gstreamer1.0-plugins-bad, gstreamer1.0-plugins-ugly, libwxgtk3.0-0v5")
+set(CPACK_DEBIAN_PACKAGE_DEPENDS      "libc6, libbsd0, libcurl4, libjsoncpp1, libxdg-basedir1, libnotify4, python2.7, python-lxml, libglibmm-2.4-1v5, libboost-filesystem${BOOST_DEB_VERSION}, libboost-system${BOOST_DEB_VERSION}, libboost-log${BOOST_DEB_VERSION}, libboost-thread${BOOST_DEB_VERSION}, libboost-program-options${BOOST_DEB_VERSION}, libgstreamer1.0-0, libappindicator3-1, gstreamer1.0-plugins-good, gstreamer1.0-plugins-bad, gstreamer1.0-plugins-ugly, libwxgtk3.0-0v5")
 set(CPACK_GENERATOR                   "DEB")
 set(CPACK_PACKAGE_FILE_NAME            ${CPACK_PACKAGE_NAME}_${PROJECT_VERSION}_${CPACK_DEBIAN_PACKAGE_ARCHITECTURE})
 set(CPACK_DEBIAN_PACKAGE_CONTROL_EXTRA ${PROJECT_SOURCE_DIR}/debian/postinst;${PROJECT_SOURCE_DIR}/debian/postrm)
 
+# no libcurl4 on Debian Stretch
+execute_process(COMMAND lsb_release -c -s OUTPUT_VARIABLE CODENAME OUTPUT_STRIP_TRAILING_WHITESPACE)
 # https://bugs.launchpad.net/ubuntu/+source/curl/+bug/1754294
 execute_process(COMMAND lsb_release -r -s OUTPUT_VARIABLE RELEASE OUTPUT_STRIP_TRAILING_WHITESPACE)
-if (${RELEASE} STREQUAL "16.04")
+if (${RELEASE} STREQUAL "16.04" OR ${CODENAME} STREQUAL "stretch")
    string(REPLACE "libcurl4" "libcurl3" CPACK_DEBIAN_PACKAGE_DEPENDS ${CPACK_DEBIAN_PACKAGE_DEPENDS})
 endif()
 


### PR DESCRIPTION
Changes necessary to build on Debian 9 (no cmake 3.10 & libcurl3 as an alternative to libcurl4).