### PR TITLE
Resolved crash.

### DIFF
--- a/src/radiotray-ng/gui/editor/editor_frame.cpp
+++ b/src/radiotray-ng/gui/editor/editor_frame.cpp
@@ -409,6 +409,7 @@ EditorFrame::onClose(wxCloseEvent& event)
 	}
 
 	this->saveConfiguration();
+	this->group_list->clearGroups();
     this->Destroy();
 }
 
@@ -424,6 +425,7 @@ EditorFrame::onQuit(wxCommandEvent& /* event */)
 	}
 
 	this->saveConfiguration();
+	this->group_list->clearGroups();
     this->Destroy();
 }
 

--- a/src/radiotray-ng/gui/editor/group_list.cpp
+++ b/src/radiotray-ng/gui/editor/group_list.cpp
@@ -99,6 +99,7 @@ GroupList::GroupList(wxWindow* parent, StationList* list) :
 
 GroupList::~GroupList()
 {
+	this->clearGroups();
 }
 
 bool
@@ -137,21 +138,24 @@ GroupList::onItemSelected(wxListEvent& event)
 void
 GroupList::onDeleteAllItems(wxListEvent& /* event */)
 {
-	this->station_list->clearStations();
-
-	long item = -1;
-	for ( ;; )
+	if (this->GetItemCount())
 	{
-		item = this->GetNextItem(item, wxLIST_NEXT_ALL, wxLIST_STATE_DONTCARE);
-		if (item == -1)
-		{
-			break;
-		}
+		this->station_list->clearStations();
 
-		GroupList::ItemData* data = reinterpret_cast<GroupList::ItemData*>(this->GetItemData(item));
-		if (data)
+		long item = -1;
+		for ( ;; )
 		{
-			delete data;
+			item = this->GetNextItem(item, wxLIST_NEXT_ALL, wxLIST_STATE_DONTCARE);
+			if (item == -1)
+			{
+				break;
+			}
+
+			GroupList::ItemData* data = reinterpret_cast<GroupList::ItemData*>(this->GetItemData(item));
+			if (data)
+			{
+				delete data;
+			}
 		}
 	}
 }

--- a/src/radiotray-ng/gui/editor/station_list.cpp
+++ b/src/radiotray-ng/gui/editor/station_list.cpp
@@ -101,6 +101,7 @@ StationList::StationList(wxWindow* parent) : wxListCtrl(parent, STATION_LIST_ID)
 
 StationList::~StationList()
 {
+	this->clearStations();
 }
 
 bool
@@ -138,19 +139,22 @@ StationList::restoreConfiguration()
 void
 StationList::onDeleteAllItems(wxListEvent& /* event */)
 {
-	long item = -1;
-	for ( ;; )
+	if (this->GetItemCount())
 	{
-		item = this->GetNextItem(item, wxLIST_NEXT_ALL, wxLIST_STATE_DONTCARE);
-		if (item == -1)
+		long item = -1;
+		for ( ;; )
 		{
-			break;
-		}
+			item = this->GetNextItem(item, wxLIST_NEXT_ALL, wxLIST_STATE_DONTCARE);
+			if (item == -1)
+			{
+				break;
+			}
 
-		StationList::ItemData* data = reinterpret_cast<StationList::ItemData*>(this->GetItemData(item));
-		if (data)
-		{
-			delete data;
+			StationList::ItemData* data = reinterpret_cast<StationList::ItemData*>(this->GetItemData(item));
+			if (data)
+			{
+				delete data;
+			}
 		}
 	}
 
@@ -230,14 +234,12 @@ StationList::addStation()
 
 	if (dlg.ShowModal() != wxID_OK)
 	{
-		dlg.Destroy();
 		return true;
 	}
 
 	std::string name, url, image;
 	bool notifications;
 	dlg.getData(name, url, image, notifications);
-	dlg.Destroy();
 
 	// trim data
 	name = radiotray_ng::trim(name);
@@ -250,7 +252,7 @@ StationList::addStation()
 	}
 
 	IBookmarks::group_data_t group = (*this->editor_bookmarks->getBookmarks().get())[this->group_index];
-	if (this->editor_bookmarks->getBookmarks()->add_station(group.group, name, url, image, true /* todo: get value from editor? */) == false)
+	if (this->editor_bookmarks->getBookmarks()->add_station(group.group, name, url, image, notifications) == false)
 	{
 		wxMessageBox(wxT("Failed to add the station."), wxT("Error"));
 		return false;


### PR DESCRIPTION
Adding a station with a name that already exists resulted in the editor crashing. This was due to a Window state issue with the modal dialog. Leaving the modal dialog in a non-destroyed state allows the editor to continue as expected. It was also found that the call to Destroy() was actually unnecessary. As such, all calls in the addStation() method were removed.

Also, used the notifications setting from the add dialog when adding a station and resolved a memory leak issue when shutting down.