### PR TITLE
Resolved crash on drag/drop with colon in name.

### DIFF
--- a/src/radiotray-ng/gui/editor/editor_app.hpp
+++ b/src/radiotray-ng/gui/editor/editor_app.hpp
@@ -32,6 +32,12 @@
 #define APPLICATION_PID_NAME	"rtng-bookmark-editor.pid"
 
 
+namespace
+{
+	const std::string TEXT_DELIMITER("\t");
+}
+
+
 class EditorApp : public wxApp
 {
 public:

--- a/src/radiotray-ng/gui/editor/group_drop_target.cpp
+++ b/src/radiotray-ng/gui/editor/group_drop_target.cpp
@@ -29,7 +29,6 @@
 
 namespace
 {
-	const std::string TEXT_DELIMITER(":::");
 }
 
 GroupDropTarget::GroupDropTarget(GroupDragAndDrop* object) :

--- a/src/radiotray-ng/gui/editor/station_drop_target.cpp
+++ b/src/radiotray-ng/gui/editor/station_drop_target.cpp
@@ -32,7 +32,6 @@
 
 namespace
 {
-	const std::string TEXT_DELIMITER(":::");
 	const int MAX_DRAG_TEXT = 20;
 	const int DRAG_FONT_POINT = 12;
 	const std::string DRAG_TAIL(" ...");


### PR DESCRIPTION
Needed to change the token used to separate the fields when performing a
drag/drop operation. The token is now the tab character, so names cannot
contain an embedded tab character.