### PR TITLE
Translation (fix #53)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -122,7 +122,7 @@ endif()
 
 # user agent
 add_custom_command(
-     OUTPUT  rtng_user_agent
+    OUTPUT  rtng_user_agent
     COMMENT "Generating rtng_user_agent.hpp"
     COMMAND ${CMAKE_COMMAND}
         -D PROJECT_SOURCE_DIR=${PROJECT_SOURCE_DIR}
@@ -136,3 +136,5 @@ add_custom_command(
 )
 
 add_custom_target(user-agent ALL DEPENDS rtng_user_agent)
+
+add_subdirectory(cmake/i18n)

--- a/cmake/i18n/CMakeLists.txt
+++ b/cmake/i18n/CMakeLists.txt
@@ -1,0 +1,92 @@
+find_package (Gettext QUIET)
+
+if (GETTEXT_FOUND)
+    find_program(GETTEXT_XGETTEXT_EXECUTABLE xgettext)
+    if(NOT GETTEXT_XGETTEXT_EXECUTABLE OR NOT GETTEXT_MSGFMT_EXECUTABLE)
+        message(FATAL_ERROR "xgettext not found")
+    endif()
+
+    find_program(GETTEXT_MSGINIT_EXECUTABLE msginit)
+    if(NOT GETTEXT_MSGINIT_EXECUTABLE)
+        message(FATAL_ERROR "msginit not found")
+    endif()
+
+    find_program(GETTEXT_MSGCAT_EXECUTABLE msgcat)
+    if(NOT GETTEXT_MSGCAT_EXECUTABLE )
+        message("msgcat not found")
+        set(TRANSLATION_TOOLS_FOUND false)
+    endif(NOT GETTEXT_MSGCAT_EXECUTABLE )
+
+    find_program(GETTEXT_MSGATTRIB_EXECUTABLE msgattrib)
+    if(NOT GETTEXT_MSGATTRIB_EXECUTABLE)
+        message("msgattrib not found")
+        set(TRANSLATION_TOOLS_FOUND false)
+    endif(NOT GETTEXT_MSGATTRIB_EXECUTABLE)
+
+    find_program(GETTEXT_MSGCAT_EXECUTABLE msgcat)
+    if(NOT GETTEXT_MSGCAT_EXECUTABLE)
+        message("msgcat not found")
+        set(TRANSLATION_TOOLS_FOUND false)
+    endif(NOT GETTEXT_MSGCAT_EXECUTABLE)
+
+    option (UPDATE_PO "Update po files" OFF)
+    option (CREATE_MO "Create mo files" ON)
+
+    option (LANGUAGES "Using translations")
+
+    ##
+    # Supported Languages
+    list (APPEND AllLanguages
+            en
+            ru
+            )
+    if (NOT DEFINED linguas)
+        set (LANGUAGES ${AllLanguages} CACHE STRING "Using translations" FORCE)
+    else (NOT DEFINED linguas)
+        if (NOT linguas)
+            set (LANGUAGES "" CACHE STRING "Using translations" FORCE)
+        elseif (linguas STREQUAL *)
+            set (LANGUAGES ${AllLanguages} CACHE STRING "Using translations" FORCE)
+        else (NOT linguas)
+            string(REGEX MATCHALL [a-zA-Z_@]+
+                    linguas1 ${linguas})
+            set (LANGUAGES ${linguas1} CACHE STRING "Using translations" FORCE)
+        endif (NOT linguas)
+    endif (NOT DEFINED linguas)
+    message (STATUS "Translations: ${LANGUAGES}")
+
+
+    ##
+    # All "po" dirs in all projects
+    list(APPEND i18n_po
+            "src/radiotray-ng/gui/appindicator/po"
+            )
+
+    ##
+    # Map
+    #         key - .mo filename;
+    #       value - "po" dirs (separated by ' + ')  - sources for .mo file.
+    #
+    # example: "some_GettextDomain.mo => src/some/dir/po + src/someOther/dir/po"
+    list(APPEND i18n_mo
+            "radiotray-ng.mo => src/radiotray-ng/gui/appindicator/po"
+            )
+
+    include("UpdatePO.cmake")
+    include("GenerateMO.cmake")
+
+
+    ##
+    # Build deps & defines
+    if(CREATE_MO)
+        add_dependencies(radiotray-ng mo-update)
+        add_dependencies(rtng-bookmark-editor mo-update)
+    endif(CREATE_MO)
+
+    set(HAVE_GETTEXT 1)
+    set(GETTEXT_DOMAIN "radiotray-ng")
+endif (GETTEXT_FOUND)
+
+configure_file(${PROJECT_SOURCE_DIR}/cmake/i18n/i18n.hpp.in ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/i18n.hpp.tmp)
+execute_process(COMMAND ${CMAKE_COMMAND} -E copy_if_different ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/i18n.hpp.tmp ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/rtng_i18n.hpp)
+execute_process(COMMAND ${CMAKE_COMMAND} -E remove ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/i18n.hpp.tmp)

--- a/cmake/i18n/GenerateMO.cmake
+++ b/cmake/i18n/GenerateMO.cmake
@@ -1,0 +1,67 @@
+if(CREATE_MO)
+
+	# main targets
+	add_custom_target(mo-update ALL
+			COMMENT "mo-update: Done."
+			)
+
+	if(UPDATE_PO)
+		# Only set the verbose flag for maintainers.
+		set(GETTEXT_MSGFMT_PARAMETER -v)
+	endif(UPDATE_PO)
+
+	foreach(i18n_mo_item ${i18n_mo})
+		string(REPLACE " => " ";" i18n_mo_item_s ${i18n_mo_item})
+
+		list(GET i18n_mo_item_s 0 mo_filename)
+		list(REMOVE_AT i18n_mo_item_s 0)
+		string(REPLACE " + " ";" i18n_mo_item_s ${i18n_mo_item_s})
+
+		string (REPLACE "/" "_" SAFE_TARGET_NAME ${mo_filename})
+
+		foreach(LANG ${LANGUAGES})
+			foreach(poDir ${i18n_mo_item_s})
+				list(APPEND ${SAFE_TARGET_NAME}_${LANG}_src "${poDir}/${LANG}.po")
+			endforeach(poDir in ${i18n_mo_item_s})
+
+			message (STATUS "mo ${mo_filename} will include [${${SAFE_TARGET_NAME}_${LANG}_src}] files for  ${LANG}")
+
+			add_custom_command(
+					OUTPUT ${PROJECT_BINARY_DIR}/${LANG}/LC_MESSAGES/${mo_filename}
+
+					COMMAND ${CMAKE_COMMAND} -E make_directory ${PROJECT_BINARY_DIR}/${LANG}/LC_MESSAGES
+
+					COMMAND ${GETTEXT_MSGCAT_EXECUTABLE}
+						-o ${PROJECT_BINARY_DIR}/${LANG}/LC_MESSAGES/${mo_filename}.po
+						${${SAFE_TARGET_NAME}_${LANG}_src}
+					WORKING_DIRECTORY
+						${PROJECT_SOURCE_DIR}
+					COMMENT "Creating merged po file ${PROJECT_BINARY_DIR}/${LANG}/LC_MESSAGES/${mo_filename}.po"
+
+					COMMAND ${GETTEXT_MSGFMT_EXECUTABLE}
+							${GETTEXT_MSGFMT_PARAMETER}
+							-o ${PROJECT_BINARY_DIR}/${LANG}/LC_MESSAGES/${mo_filename}
+							${PROJECT_BINARY_DIR}/${LANG}/LC_MESSAGES/${mo_filename}.po
+					WORKING_DIRECTORY
+						${PROJECT_SOURCE_DIR}
+					COMMENT "Creating mo file ${PROJECT_BINARY_DIR}/${LANG}/LC_MESSAGES/${mo_filename}"
+			)
+
+			list(APPEND mo-update-${SAFE_TARGET_NAME}-SRC
+					${PROJECT_BINARY_DIR}/${LANG}/LC_MESSAGES/${mo_filename}
+					)
+		endforeach(LANG ${LANGUAGES})
+
+		add_custom_target(mo-update-${SAFE_TARGET_NAME}
+				COMMENT "mo-update-${SAFE_TARGET_NAME}: Done for ${mo_filename}."
+				DEPENDS ${mo-update-${SAFE_TARGET_NAME}-SRC}
+				)
+
+		add_dependencies("mo-update" mo-update-${SAFE_TARGET_NAME})
+	endforeach(i18n_mo_item ${i18n_mo})
+
+	if(UPDATE_PO)
+		add_dependencies("mo-update" po-update)
+	endif(UPDATE_PO)
+
+endif(CREATE_MO)

--- a/cmake/i18n/UpdatePO.cmake
+++ b/cmake/i18n/UpdatePO.cmake
@@ -1,0 +1,116 @@
+if(UPDATE_PO)
+
+	# main targets
+	add_custom_target(pot-update
+			COMMENT "pot-update: Done."
+			)
+	add_custom_target(po-update
+			COMMENT "po-update: Done."
+			)
+
+	foreach(i18n_dir ${i18n_po})
+		string (REPLACE "/" "_" SAFE_TARGET_NAME ${i18n_dir})
+		string (CONCAT i18n_dir_full ${PROJECT_SOURCE_DIR} "/" ${i18n_dir})
+
+		add_custom_command(
+			OUTPUT ${i18n_dir_full}/i18n.pot
+
+			COMMAND touch
+				${i18n_dir_full}/i18n.pot
+
+			COMMAND ${GETTEXT_XGETTEXT_EXECUTABLE}
+				--add-comments=TRANSLATORS
+				--files-from="${i18n_dir_full}/src.txt"
+				--copyright-holder=\"radiotray-ng team\"
+				--msgid-bugs-address=\"https://github.com/ebruck/radiotray-ng/issues\"
+				--from-code=UTF-8
+				--keyword=_
+				--keyword=N_
+				--keyword=F_
+				--keyword=F_:2 --flag=F_:2:pass-c-format
+				--keyword=FN_
+				--output=${i18n_dir_full}/i18n.pot
+				--sort-output
+				--add-comments=i18n
+			# replace the chartype
+			COMMAND sed -i
+				s/charset=CHARSET/charset=UTF-8/
+				${i18n_dir_full}/i18n.pot
+			DEPENDS "${i18n_dir_full}/src.txt"
+			WORKING_DIRECTORY ${i18n_dir_full}
+			COMMENT "pot-update: Generated source pot file in ${i18n_dir_full}."
+		)
+
+		add_custom_target(pot-update-${SAFE_TARGET_NAME}
+				COMMENT "pot-update: Done in ${i18n_dir_full}."
+				DEPENDS  ${i18n_dir_full}/i18n.pot
+				)
+
+		add_dependencies("pot-update" pot-update-${SAFE_TARGET_NAME})
+
+		# Generate/Update the po files for all languages
+		foreach(LANG ${LANGUAGES})
+			### Generate/update po file.
+			# For some reason CMake is rather happy to delete the po file in
+			# some cases. Too avoid that problem only generate the init rule
+			# if the po file doesn't exist. The case where a po file used to
+			# exist and no longer exists should never occur
+			if(NOT EXISTS ${i18n_dir_full}/${LANG}.po)
+				add_custom_command(
+					OUTPUT ${i18n_dir_full}/${LANG}.po.dummy
+					COMMAND ${GETTEXT_MSGINIT_EXECUTABLE}
+							--no-translator
+							--input=i18n.pot
+							--output-file=${LANG}.po
+							--locale=${LANG}
+					WORKING_DIRECTORY ${i18n_dir_full}
+					DEPENDS
+						${i18n_dir_full}/i18n.pot
+					COMMENT
+						"po-update ${LANG}: Initialized po file in ${i18n_dir_full}."
+				)
+
+			else(NOT EXISTS ${i18n_dir_full}/${LANG}.po)
+				add_custom_command(
+						OUTPUT ${i18n_dir_full}/${LANG}.po.dummy
+						# After the po file is updated it might look not entirely as
+						# wanted, for example poedit reorders the file. Use msgattrib
+						# to reformat the file, use a helper file to do so.
+						COMMAND ${GETTEXT_MSGATTRIB_EXECUTABLE}
+								--output ${LANG}.po.tmp
+								${LANG}.po
+						COMMAND ${CMAKE_COMMAND} -E copy
+								${LANG}.po.tmp
+								${LANG}.po
+						COMMAND ${CMAKE_COMMAND} -E remove
+								${LANG}.po.tmp
+						# Now merge with the pot file.
+						COMMAND ${GETTEXT_MSGMERGE_EXECUTABLE}
+								--backup=none
+								--update
+								${LANG}.po
+								i18n.pot
+						WORKING_DIRECTORY ${i18n_dir_full}
+						DEPENDS
+							${i18n_dir_full}/i18n.pot
+						COMMENT
+							"po-update ${LANG}: Update po file in ${i18n_dir_full}."
+				)
+			endif(NOT EXISTS ${i18n_dir_full}/${LANG}.po)
+
+			SET(po-update-${SAFE_TARGET_NAME}-SRC
+					${po-update-${SAFE_TARGET_NAME}-SRC}
+					${i18n_dir_full}/${LANG}.po.dummy
+					)
+		endforeach(LANG ${LANGUAGES})
+
+
+		add_custom_target(po-update-${SAFE_TARGET_NAME}
+				COMMENT "po-update: Done in ${i18n_dir_full}."
+				DEPENDS ${po-update-${SAFE_TARGET_NAME}-SRC}
+				)
+
+		add_dependencies("po-update" po-update-${SAFE_TARGET_NAME})
+	endforeach(i18n_dir in ${i18n_po})
+
+endif(UPDATE_PO)

--- a/cmake/i18n/i18n.hpp.in
+++ b/cmake/i18n/i18n.hpp.in
@@ -1,0 +1,35 @@
+#ifndef RADIOTRAY_NG_I18N_H
+#define RADIOTRAY_NG_I18N_H
+
+#cmakedefine HAVE_GETTEXT ${HAVE_GETTEXT}
+#cmakedefine GETTEXT_DOMAIN "${GETTEXT_DOMAIN}"
+
+
+
+#ifndef HAVE_GETTEXT
+#define HAVE_GETTEXT		0
+#endif /* !defined HAVE_GETTEXT */
+
+
+#if HAVE_GETTEXT
+#include "libintl.h"
+#endif /* HAVE_GETTEXT */
+
+/*
+** For the benefit of GNU folk...
+** `_(MSGID)' uses the current locale's message library string for MSGID.
+** The default is to use gettext if available, and use MSGID otherwise.
+*/
+
+#ifndef _
+#if HAVE_GETTEXT
+#define _(msgid) gettext(msgid)
+#else /* !HAVE_GETTEXT */
+#define _(msgid) msgid
+#endif /* !HAVE_GETTEXT */
+#endif /* !defined _ */
+
+
+
+
+#endif //RADIOTRAY_NG_I18N_H

--- a/docker/ubuntu/16.04/Dockerfile
+++ b/docker/ubuntu/16.04/Dockerfile
@@ -21,5 +21,6 @@ RUN set -ex; \
                    libglibmm-2.4-dev \
                    libwxgtk3.0-dev \
                    libwxgtk3.0-0v5 \
+                   intltool \
         && wget -qO- "https://github.com/Kitware/CMake/releases/download/v3.14.3/cmake-3.14.3-Linux-x86_64.tar.gz" | tar --strip-components=1 -xz -C /usr/local \
         && rm -rf /var/lib/apt/lists/*

--- a/docker/ubuntu/18.04/Dockerfile
+++ b/docker/ubuntu/18.04/Dockerfile
@@ -21,4 +21,5 @@ RUN set -ex; \
                    libglibmm-2.4-dev \
                    libwxgtk3.0-dev \
                    libwxgtk3.0-0v5 \
+                   intltool \
         && rm -rf /var/lib/apt/lists/*

--- a/docker/ubuntu/19.04/Dockerfile
+++ b/docker/ubuntu/19.04/Dockerfile
@@ -21,4 +21,5 @@ RUN set -ex; \
                    libglibmm-2.4-dev \
                    libwxgtk3.0-dev \
                    libwxgtk3.0-0v5 \
+                   intltool \
         && rm -rf /var/lib/apt/lists/*

--- a/include/radiotray-ng/common.hpp
+++ b/include/radiotray-ng/common.hpp
@@ -23,6 +23,8 @@
 #include <string>
 #include <iomanip>
 
+#include <rtng_i18n.hpp>
+
 using playlist_t = std::vector<std::string>;
 
 // logging

--- a/package/CMakeLists.txt
+++ b/package/CMakeLists.txt
@@ -135,6 +135,10 @@ if (LSB_RELEASE_EXECUTABLE)
     install(PROGRAMS  ${PROJECT_BINARY_DIR}/radiotray-ng                            DESTINATION /usr/bin/)
     install(PROGRAMS  ${PROJECT_BINARY_DIR}/rtng-bookmark-editor                    DESTINATION /usr/bin/)
 
+    foreach(LANG ${LANGUAGES})
+        install(DIRECTORY ${PROJECT_BINARY_DIR}/${LANG}/LC_MESSAGES DESTINATION /usr/share/locale/${LANG} OPTIONAL FILES_MATCHING PATTERN *.mo)
+    endforeach(LANG ${LANGUAGES})
+
     include(CPack)
 else()
     message(AUTHOR_WARNING "lsb_release not found! -- packaging disabled")

--- a/src/radiotray-ng/CMakeLists.txt
+++ b/src/radiotray-ng/CMakeLists.txt
@@ -37,4 +37,5 @@ target_link_libraries(
 )
 
 add_dependencies(radiotray-ng user-agent)
+
 target_include_directories(radiotray-ng SYSTEM PRIVATE ${CMAKE_RUNTIME_OUTPUT_DIRECTORY} ${GSTREAMER_INCLUDE_DIRS} ${APPINDICATOR_INCLUDE_DIRS} ${GIOMM_INCLUDE_DIRS} ${GLIBMM_INCLUDE_DIRS})

--- a/src/radiotray-ng/extras/rtng_dbus/rtng_dbus.cpp
+++ b/src/radiotray-ng/extras/rtng_dbus/rtng_dbus.cpp
@@ -32,9 +32,9 @@ namespace
 		"    </method>"
 		"    <method name='play'>"
 		"    </method>"
-        "    <method name='mute'>"
-        "    </method>"
-        "    <method name='stop'>"
+		"    <method name='mute'>"
+		"    </method>"
+		"    <method name='stop'>"
 		"    </method>"
 		"    <method name='quit'>"
 		"    </method>"
@@ -106,12 +106,12 @@ void RtngDbus::on_method_call(const Glib::RefPtr<Gio::DBus::Connection>& /*conne
 		return;
 	}
 
-    if (method_name == "mute")
-    {
-        this->radiotray_ng->mute();
-        invocation->return_value(Glib::VariantContainerBase());
-        return;
-    }
+	if (method_name == "mute")
+	{
+		this->radiotray_ng->mute();
+		invocation->return_value(Glib::VariantContainerBase());
+		return;
+	}
 
 	if (method_name == "stop")
 	{

--- a/src/radiotray-ng/extras/rtng_dbus/rtng_dbus.cpp
+++ b/src/radiotray-ng/extras/rtng_dbus/rtng_dbus.cpp
@@ -254,8 +254,6 @@ void RtngDbus::on_bus_acquired(const Glib::RefPtr<Gio::DBus::Connection>& connec
 
 void RtngDbus::dbus_setup()
 {
-	//std::locale::global(std::locale(""));
-
 	Gio::init();
 
 	try

--- a/src/radiotray-ng/extras/rtng_dbus/rtng_dbus.cpp
+++ b/src/radiotray-ng/extras/rtng_dbus/rtng_dbus.cpp
@@ -254,7 +254,7 @@ void RtngDbus::on_bus_acquired(const Glib::RefPtr<Gio::DBus::Connection>& connec
 
 void RtngDbus::dbus_setup()
 {
-	std::locale::global(std::locale(""));
+	//std::locale::global(std::locale(""));
 
 	Gio::init();
 

--- a/src/radiotray-ng/gui/appindicator/appindicator_gui.cpp
+++ b/src/radiotray-ng/gui/appindicator/appindicator_gui.cpp
@@ -21,7 +21,6 @@
 #include <radiotray-ng/i_radiotray_ng.hpp>
 #include <rtng_user_agent.hpp>
 
-
 AppindicatorGui::AppindicatorGui(std::shared_ptr<IConfig> config, std::shared_ptr<IRadioTrayNG> radiotray_ng,
 	                             std::shared_ptr<IBookmarks> bookmarks, std::shared_ptr<IEventBus> event_bus)
 	: radiotray_ng(std::move(radiotray_ng))
@@ -262,14 +261,14 @@ void AppindicatorGui::add_separator(GtkWidget* menu)
 
 void AppindicatorGui::update_volume_menu_item()
 {
-	std::string volume_info{std::string("Volume: ") + this->radiotray_ng->get_volume() + std::string("%")};
+	std::string volume_info{std::string(_("Volume")) + ": " + this->radiotray_ng->get_volume() + "%"};
 
 	if (this->config->get_bool(TAG_INFO_VERBOSE_KEY, DEFAULT_TAG_INFO_VERBOSE_VALUE))
 	{
 		std::string bitrate = this->radiotray_ng->get_bitrate();
 		if (!bitrate.empty())
 		{
-			std::string bitrate_info{std::string(", Bitrate: ") + bitrate};
+			std::string bitrate_info{std::string(", ")+ _("Bitrate") + ": " + bitrate};
 
 			volume_info += bitrate_info;
 		}
@@ -277,7 +276,7 @@ void AppindicatorGui::update_volume_menu_item()
 		std::string codec = this->radiotray_ng->get_codec();
 		if (!codec.empty())
 		{
-			std::string codec_info{std::string("\nCodec: ") + codec};
+			std::string codec_info{std::string("\n") + _("Codec") + ": " + codec};
 
 			volume_info += codec_info;
 		}
@@ -294,7 +293,7 @@ void AppindicatorGui::update_action_menu_item(const std::string& state)
 
 	if (state == STATE_STOPPED)
 	{
-		action_text = "Turn On";
+		action_text = _("Turn On");
 
 		if (!this->radiotray_ng->get_station().empty())
 		{
@@ -312,7 +311,7 @@ void AppindicatorGui::update_action_menu_item(const std::string& state)
 
 	if (state == STATE_PLAYING || state == STATE_BUFFERING)
 	{
-		action_text = "Turn Off";
+		action_text = _("Turn Off");
 
 		if (!this->radiotray_ng->get_station().empty())
 		{
@@ -339,7 +338,7 @@ void AppindicatorGui::update_status_menu_item(const std::string& state)
 		// at least a title will be there...
 		if (title.empty())
 		{
-			status_text = std::string("Playing");
+			status_text = std::string(_("Playing"));
 
 			if (copy_enabled)
 			{
@@ -382,7 +381,7 @@ void AppindicatorGui::update_status_menu_item(const std::string& state)
 
 	if (state == STATE_STOPPED)
 	{
-		gtk_menu_item_set_label(GTK_MENU_ITEM(this->status_menu_item), std::string("Stopped").c_str());
+		gtk_menu_item_set_label(GTK_MENU_ITEM(this->status_menu_item), _("Stopped"));
 
 		if (copy_enabled)
 		{
@@ -397,7 +396,7 @@ void AppindicatorGui::build_status_menu_item()
 {
 	this->add_separator(this->menu);
 
-	this->status_menu_item = gtk_menu_item_new_with_label("status");
+	this->status_menu_item = gtk_menu_item_new_with_label(_("status"));
 	gtk_menu_shell_append(GTK_MENU_SHELL(this->menu), this->status_menu_item);
 	gtk_widget_set_sensitive(this->status_menu_item, FALSE);
 
@@ -419,7 +418,7 @@ void AppindicatorGui::build_status_menu_item()
 
 void AppindicatorGui::build_action_menu_item()
 {
-	this->action_menu_item = gtk_menu_item_new_with_label("action");
+	this->action_menu_item = gtk_menu_item_new_with_label(_("action"));
 	gtk_menu_shell_append(GTK_MENU_SHELL(this->menu), this->action_menu_item);
 	gtk_widget_show(this->action_menu_item);
 
@@ -435,7 +434,7 @@ void AppindicatorGui::build_volume_menu_item()
 {
 	this->add_separator(this->menu);
 
-	this->volume_menu_item = gtk_menu_item_new_with_label("volume");
+	this->volume_menu_item = gtk_menu_item_new_with_label(_("volume"));
 	gtk_menu_shell_append(GTK_MENU_SHELL(this->menu), this->volume_menu_item);
 	gtk_widget_show(this->volume_menu_item);
 
@@ -447,19 +446,19 @@ void AppindicatorGui::build_preferences_menu()
 {
 	this->add_separator(this->menu);
 
-	GtkWidget* menu_items = gtk_menu_item_new_with_label("Preferences");
+	GtkWidget* menu_items = gtk_menu_item_new_with_label(_("Preferences"));
 	gtk_menu_shell_append(GTK_MENU_SHELL(this->menu), menu_items);
 	gtk_widget_show(menu_items);
 
 	GtkWidget* sub_menu_items = gtk_menu_new();
 	gtk_menu_item_set_submenu(GTK_MENU_ITEM(menu_items), sub_menu_items);
 
-	GtkWidget* sub_menu_item = gtk_menu_item_new_with_label("Bookmark Editor...");
+	GtkWidget* sub_menu_item = gtk_menu_item_new_with_label(_("Bookmark Editor..."));
 	gtk_menu_shell_append(GTK_MENU_SHELL(sub_menu_items), sub_menu_item);
 	g_signal_connect(G_OBJECT(sub_menu_item), "activate", G_CALLBACK(on_bookmark_editor_menu_item), gpointer(this));
 	gtk_widget_show(sub_menu_item);
 
-	sub_menu_item = gtk_menu_item_new_with_label("Reload Bookmarks");
+	sub_menu_item = gtk_menu_item_new_with_label(_("Reload Bookmarks"));
 	gtk_menu_shell_append(GTK_MENU_SHELL(sub_menu_items), sub_menu_item);
 	g_signal_connect(G_OBJECT(sub_menu_item), "activate", G_CALLBACK(on_reload_bookmarks_menu_item), gpointer(this));
 	gtk_widget_show(sub_menu_item);
@@ -468,7 +467,7 @@ void AppindicatorGui::build_preferences_menu()
 
 void AppindicatorGui::build_sleep_timer_menu_item()
 {
-	this->sleep_timer_menu_item = (GtkCheckMenuItem*)gtk_check_menu_item_new_with_label("Sleep Timer");
+	this->sleep_timer_menu_item = (GtkCheckMenuItem*)gtk_check_menu_item_new_with_label(_("Sleep Timer"));
 
 	// toggle before we hook up callback as a reload loses this state...
 	gtk_check_menu_item_set_active(this->sleep_timer_menu_item, this->sleep_timer_id);
@@ -481,7 +480,7 @@ void AppindicatorGui::build_sleep_timer_menu_item()
 
 void AppindicatorGui::build_about_menu_item()
 {
-	auto menu_items = gtk_menu_item_new_with_label("About");
+	auto menu_items = gtk_menu_item_new_with_label(_("About"));
 	gtk_menu_shell_append(GTK_MENU_SHELL (this->menu), menu_items);
 	g_signal_connect(menu_items, "activate", G_CALLBACK(&AppindicatorGui::on_about_menu_item), this);
 	gtk_widget_show(menu_items);
@@ -490,7 +489,7 @@ void AppindicatorGui::build_about_menu_item()
 
 void AppindicatorGui::build_quit_menu_item()
 {
-	auto menu_items = gtk_menu_item_new_with_label("Quit");
+	auto menu_items = gtk_menu_item_new_with_label(_("Quit"));
 	gtk_menu_shell_append(GTK_MENU_SHELL (this->menu), menu_items);
 	g_signal_connect(menu_items, "activate", GCallback(gtk_main_quit), nullptr);
 	gtk_widget_show(menu_items);
@@ -577,7 +576,7 @@ gboolean AppindicatorGui::on_timer_event(gpointer data)
 
 	gtk_check_menu_item_set_active(app->sleep_timer_menu_item, FALSE);
 
-	app->event_bus->publish_only(IEventBus::event::message, MESSAGE_KEY, "Sleep timer expired");
+	app->event_bus->publish_only(IEventBus::event::message, MESSAGE_KEY, _("Sleep timer expired"));
 
 	return FALSE;
 }
@@ -589,7 +588,7 @@ gboolean AppindicatorGui::on_file_monitor_timer_event(gpointer data)
 
 	if (app->bookmarks_monitor->changed())
 	{
-		app->event_bus->publish_only(IEventBus::event::message, MESSAGE_KEY, "Bookmarks changed on disk");
+		app->event_bus->publish_only(IEventBus::event::message, MESSAGE_KEY, _("Bookmarks changed on disk"));
 	}
 
 	return TRUE;
@@ -598,18 +597,18 @@ gboolean AppindicatorGui::on_file_monitor_timer_event(gpointer data)
 
 bool AppindicatorGui::sleep_timer_dialog()
 {
-	auto dialog = gtk_dialog_new_with_buttons("Sleep Timer",
+	auto dialog = gtk_dialog_new_with_buttons(_("Sleep Timer"),
 		nullptr,
 		GTK_DIALOG_DESTROY_WITH_PARENT,
-		"Cancel",
+		_("Cancel"),
 		GTK_RESPONSE_REJECT,
-		"OK",
+		_("OK"),
 		GTK_RESPONSE_ACCEPT,
 		nullptr);
 
 	auto entry = gtk_entry_new();
 	gtk_entry_set_max_length(GTK_ENTRY(entry), 4);
-	auto label = gtk_label_new("Minutes:");
+	auto label = gtk_label_new((std::string(_("Minutes")) + ":").c_str());
 	auto hbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
 
 	gtk_entry_set_text(GTK_ENTRY(entry), this->config->get_string(SLEEP_TIMER_KEY, std::to_string(DEFAULT_SLEEP_TIMER_VALUE)).c_str());
@@ -636,7 +635,7 @@ bool AppindicatorGui::sleep_timer_dialog()
 			}
 			catch(std::invalid_argument& ex)
 			{
-				this->event_bus->publish_only(IEventBus::event::message, MESSAGE_KEY, "Invalid sleep timer");
+				this->event_bus->publish_only(IEventBus::event::message, MESSAGE_KEY, _("Invalid sleep timer"));
 
 				return false;
 			}
@@ -666,14 +665,14 @@ void AppindicatorGui::on_sleep_timer_menu_item(GtkWidget* /*widget*/, gpointer d
 
 		app->sleep_timer_id = 0;
 
-		app->event_bus->publish_only(IEventBus::event::message, MESSAGE_KEY, "Sleep timer stopped");
+		app->event_bus->publish_only(IEventBus::event::message, MESSAGE_KEY, _("Sleep timer stopped"));
 	}
 	else
 	{
 		if (app->sleep_timer_dialog())
 		{
 			app->event_bus->publish_only(IEventBus::event::message, MESSAGE_KEY,
-				std::to_string(app->config->get_uint32(SLEEP_TIMER_KEY, DEFAULT_SLEEP_TIMER_VALUE)) + " minute sleep timer started");
+				std::to_string(app->config->get_uint32(SLEEP_TIMER_KEY, DEFAULT_SLEEP_TIMER_VALUE)) + " " + _("minute sleep timer started"));
 
 			app->sleep_timer_id = g_timeout_add(
 				app->config->get_uint32(SLEEP_TIMER_KEY, DEFAULT_SLEEP_TIMER_VALUE) * 60000, on_timer_event, data);
@@ -776,8 +775,7 @@ void AppindicatorGui::reload_bookmarks()
 
 void AppindicatorGui::run(int argc, char* argv[])
 {
-	gtk_init(&argc, &argv);
-
+    gtk_init(&argc, &argv);
 	const std::string icon_off{radiotray_ng::word_expand(this->config->get_string(RADIOTRAY_NG_ICON_OFF_KEY, DEFAULT_RADIOTRAY_NG_ICON_OFF_VALUE))};
 
 	this->appindicator = app_indicator_new(APP_NAME, icon_off.c_str(), APP_INDICATOR_CATEGORY_APPLICATION_STATUS);

--- a/src/radiotray-ng/gui/appindicator/appindicator_gui.cpp
+++ b/src/radiotray-ng/gui/appindicator/appindicator_gui.cpp
@@ -22,7 +22,7 @@
 #include <rtng_user_agent.hpp>
 
 AppindicatorGui::AppindicatorGui(std::shared_ptr<IConfig> config, std::shared_ptr<IRadioTrayNG> radiotray_ng,
-	                             std::shared_ptr<IBookmarks> bookmarks, std::shared_ptr<IEventBus> event_bus)
+								 std::shared_ptr<IBookmarks> bookmarks, std::shared_ptr<IEventBus> event_bus)
 	: radiotray_ng(std::move(radiotray_ng))
 	, bookmarks(std::move(bookmarks))
 	, config(std::move(config))
@@ -775,7 +775,7 @@ void AppindicatorGui::reload_bookmarks()
 
 void AppindicatorGui::run(int argc, char* argv[])
 {
-    gtk_init(&argc, &argv);
+	gtk_init(&argc, &argv);
 	const std::string icon_off{radiotray_ng::word_expand(this->config->get_string(RADIOTRAY_NG_ICON_OFF_KEY, DEFAULT_RADIOTRAY_NG_ICON_OFF_VALUE))};
 
 	this->appindicator = app_indicator_new(APP_NAME, icon_off.c_str(), APP_INDICATOR_CATEGORY_APPLICATION_STATUS);

--- a/src/radiotray-ng/gui/appindicator/appindicator_gui.hpp
+++ b/src/radiotray-ng/gui/appindicator/appindicator_gui.hpp
@@ -25,6 +25,9 @@
 #include <libappindicator/app-indicator.h>
 #include <memory>
 
+#include <libintl.h>
+#include <locale.h>
+
 class IConfig;
 class IBookmarks;
 class IPlayer;

--- a/src/radiotray-ng/gui/appindicator/po/en.po
+++ b/src/radiotray-ng/gui/appindicator/po/en.po
@@ -1,0 +1,152 @@
+# English translations for PACKAGE package.
+# Copyright (C) 2019 radiotray-ng team
+# This file is distributed under the same license as the PACKAGE package.
+# Automatically generated, 2019.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://github.com/ebruck/radiotray-ng/issues\n"
+"POT-Creation-Date: 2019-07-30 01:11+0300\n"
+"PO-Revision-Date: 2019-07-23 23:51+0300\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: en\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: ../../../radiotray_ng.cpp:595
+msgid "(Mute)"
+msgstr ""
+
+#: ../appindicator_gui.cpp:483
+msgid "About"
+msgstr "About"
+
+#: ../appindicator_gui.cpp:271
+msgid "Bitrate"
+msgstr "Bitrate"
+
+#: ../appindicator_gui.cpp:456
+msgid "Bookmark Editor..."
+msgstr "Bookmark Editor..."
+
+#: ../../../radiotray_ng.cpp:656
+msgid "Bookmarks Reload Failed"
+msgstr ""
+
+#: ../../../radiotray_ng.cpp:647
+#, fuzzy
+msgid "Bookmarks Reloaded"
+msgstr "Bookmarks changed on disk"
+
+#: ../appindicator_gui.cpp:591
+msgid "Bookmarks changed on disk"
+msgstr "Bookmarks changed on disk"
+
+#: ../../../radiotray_ng.cpp:401
+msgid "Buffering"
+msgstr ""
+
+#: ../appindicator_gui.cpp:603
+msgid "Cancel"
+msgstr "Cancel"
+
+#: ../appindicator_gui.cpp:279
+msgid "Codec"
+msgstr "Codec"
+
+#: ../../../radiotray_ng.cpp:393
+msgid "Connecting"
+msgstr ""
+
+#: ../../../radiotray_ng.cpp:412
+msgid "Error"
+msgstr ""
+
+#: ../../../radiotray_ng.cpp:536
+msgid "Failed to download playlist"
+msgstr ""
+
+#: ../appindicator_gui.cpp:638
+msgid "Invalid sleep timer"
+msgstr "Invalid sleep timer"
+
+#: ../appindicator_gui.cpp:611
+msgid "Minutes"
+msgstr "Minutes"
+
+#: ../appindicator_gui.cpp:605
+msgid "OK"
+msgstr "OK"
+
+#: ../appindicator_gui.cpp:341
+msgid "Playing"
+msgstr "Playing"
+
+#: ../appindicator_gui.cpp:449
+msgid "Preferences"
+msgstr "Preferences"
+
+#: ../appindicator_gui.cpp:492
+msgid "Quit"
+msgstr "Quit"
+
+#: ../appindicator_gui.cpp:461
+msgid "Reload Bookmarks"
+msgstr "Reload Bookmarks"
+
+#: ../appindicator_gui.cpp:470 ../appindicator_gui.cpp:600
+msgid "Sleep Timer"
+msgstr "Sleep Timer"
+
+#: ../appindicator_gui.cpp:579
+msgid "Sleep timer expired"
+msgstr "Sleep timer expired"
+
+#: ../appindicator_gui.cpp:668
+msgid "Sleep timer stopped"
+msgstr "Sleep timer stopped"
+
+#: ../../../radiotray_ng.cpp:542
+msgid "Station Error"
+msgstr ""
+
+#: ../appindicator_gui.cpp:384 ../../../radiotray_ng.cpp:64
+msgid "Stopped"
+msgstr "Stopped"
+
+#: ../appindicator_gui.cpp:314
+msgid "Turn Off"
+msgstr "Turn Off"
+
+#: ../appindicator_gui.cpp:296
+msgid "Turn On"
+msgstr "Turn On"
+
+#: ../appindicator_gui.cpp:264 ../../../radiotray_ng.cpp:589
+#: ../../../radiotray_ng.cpp:632
+msgid "Volume"
+msgstr "Volume"
+
+#: ../appindicator_gui.cpp:421
+msgid "action"
+msgstr "action"
+
+#: ../../../radiotray_ng.cpp:353
+msgid "kb/s"
+msgstr ""
+
+#: ../appindicator_gui.cpp:675
+msgid "minute sleep timer started"
+msgstr "minute sleep timer started"
+
+#: ../appindicator_gui.cpp:399
+msgid "status"
+msgstr "status"
+
+#: ../appindicator_gui.cpp:437
+msgid "volume"
+msgstr "volume"

--- a/src/radiotray-ng/gui/appindicator/po/en.po
+++ b/src/radiotray-ng/gui/appindicator/po/en.po
@@ -19,7 +19,7 @@ msgstr ""
 
 #: ../../../radiotray_ng.cpp:595
 msgid "(Mute)"
-msgstr ""
+msgstr "(Mute)"
 
 #: ../appindicator_gui.cpp:483
 msgid "About"
@@ -35,12 +35,12 @@ msgstr "Bookmark Editor..."
 
 #: ../../../radiotray_ng.cpp:656
 msgid "Bookmarks Reload Failed"
-msgstr ""
+msgstr "Bookmarks Reload Failed"
 
 #: ../../../radiotray_ng.cpp:647
 #, fuzzy
 msgid "Bookmarks Reloaded"
-msgstr "Bookmarks changed on disk"
+msgstr "Bookmarks Reloaded"
 
 #: ../appindicator_gui.cpp:591
 msgid "Bookmarks changed on disk"
@@ -48,7 +48,7 @@ msgstr "Bookmarks changed on disk"
 
 #: ../../../radiotray_ng.cpp:401
 msgid "Buffering"
-msgstr ""
+msgstr "Buffering"
 
 #: ../appindicator_gui.cpp:603
 msgid "Cancel"
@@ -60,15 +60,15 @@ msgstr "Codec"
 
 #: ../../../radiotray_ng.cpp:393
 msgid "Connecting"
-msgstr ""
+msgstr "Connecting"
 
 #: ../../../radiotray_ng.cpp:412
 msgid "Error"
-msgstr ""
+msgstr "Error"
 
 #: ../../../radiotray_ng.cpp:536
 msgid "Failed to download playlist"
-msgstr ""
+msgstr "Failed to download playlist"
 
 #: ../appindicator_gui.cpp:638
 msgid "Invalid sleep timer"
@@ -112,7 +112,7 @@ msgstr "Sleep timer stopped"
 
 #: ../../../radiotray_ng.cpp:542
 msgid "Station Error"
-msgstr ""
+msgstr "Station Error"
 
 #: ../appindicator_gui.cpp:384 ../../../radiotray_ng.cpp:64
 msgid "Stopped"
@@ -137,7 +137,7 @@ msgstr "action"
 
 #: ../../../radiotray_ng.cpp:353
 msgid "kb/s"
-msgstr ""
+msgstr "kb/s"
 
 #: ../appindicator_gui.cpp:675
 msgid "minute sleep timer started"

--- a/src/radiotray-ng/gui/appindicator/po/i18n.pot
+++ b/src/radiotray-ng/gui/appindicator/po/i18n.pot
@@ -1,0 +1,151 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR radiotray-ng team
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://github.com/ebruck/radiotray-ng/issues\n"
+"POT-Creation-Date: 2019-07-30 01:11+0300\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: ../../../radiotray_ng.cpp:595
+msgid "(Mute)"
+msgstr ""
+
+#: ../appindicator_gui.cpp:483
+msgid "About"
+msgstr ""
+
+#: ../appindicator_gui.cpp:271
+msgid "Bitrate"
+msgstr ""
+
+#: ../appindicator_gui.cpp:456
+msgid "Bookmark Editor..."
+msgstr ""
+
+#: ../../../radiotray_ng.cpp:656
+msgid "Bookmarks Reload Failed"
+msgstr ""
+
+#: ../../../radiotray_ng.cpp:647
+msgid "Bookmarks Reloaded"
+msgstr ""
+
+#: ../appindicator_gui.cpp:591
+msgid "Bookmarks changed on disk"
+msgstr ""
+
+#: ../../../radiotray_ng.cpp:401
+msgid "Buffering"
+msgstr ""
+
+#: ../appindicator_gui.cpp:603
+msgid "Cancel"
+msgstr ""
+
+#: ../appindicator_gui.cpp:279
+msgid "Codec"
+msgstr ""
+
+#: ../../../radiotray_ng.cpp:393
+msgid "Connecting"
+msgstr ""
+
+#: ../../../radiotray_ng.cpp:412
+msgid "Error"
+msgstr ""
+
+#: ../../../radiotray_ng.cpp:536
+msgid "Failed to download playlist"
+msgstr ""
+
+#: ../appindicator_gui.cpp:638
+msgid "Invalid sleep timer"
+msgstr ""
+
+#: ../appindicator_gui.cpp:611
+msgid "Minutes"
+msgstr ""
+
+#: ../appindicator_gui.cpp:605
+msgid "OK"
+msgstr ""
+
+#: ../appindicator_gui.cpp:341
+msgid "Playing"
+msgstr ""
+
+#: ../appindicator_gui.cpp:449
+msgid "Preferences"
+msgstr ""
+
+#: ../appindicator_gui.cpp:492
+msgid "Quit"
+msgstr ""
+
+#: ../appindicator_gui.cpp:461
+msgid "Reload Bookmarks"
+msgstr ""
+
+#: ../appindicator_gui.cpp:470 ../appindicator_gui.cpp:600
+msgid "Sleep Timer"
+msgstr ""
+
+#: ../appindicator_gui.cpp:579
+msgid "Sleep timer expired"
+msgstr ""
+
+#: ../appindicator_gui.cpp:668
+msgid "Sleep timer stopped"
+msgstr ""
+
+#: ../../../radiotray_ng.cpp:542
+msgid "Station Error"
+msgstr ""
+
+#: ../appindicator_gui.cpp:384 ../../../radiotray_ng.cpp:64
+msgid "Stopped"
+msgstr ""
+
+#: ../appindicator_gui.cpp:314
+msgid "Turn Off"
+msgstr ""
+
+#: ../appindicator_gui.cpp:296
+msgid "Turn On"
+msgstr ""
+
+#: ../appindicator_gui.cpp:264 ../../../radiotray_ng.cpp:589
+#: ../../../radiotray_ng.cpp:632
+msgid "Volume"
+msgstr ""
+
+#: ../appindicator_gui.cpp:421
+msgid "action"
+msgstr ""
+
+#: ../../../radiotray_ng.cpp:353
+msgid "kb/s"
+msgstr ""
+
+#: ../appindicator_gui.cpp:675
+msgid "minute sleep timer started"
+msgstr ""
+
+#: ../appindicator_gui.cpp:399
+msgid "status"
+msgstr ""
+
+#: ../appindicator_gui.cpp:437
+msgid "volume"
+msgstr ""

--- a/src/radiotray-ng/gui/appindicator/po/ru.po
+++ b/src/radiotray-ng/gui/appindicator/po/ru.po
@@ -1,0 +1,153 @@
+# Russian translations for PACKAGE package.
+# Copyright (C) 2019 radiotray-ng team
+# This file is distributed under the same license as the PACKAGE package.
+# Automatically generated, 2019.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: https://github.com/ebruck/radiotray-ng/issues\n"
+"POT-Creation-Date: 2019-07-30 01:11+0300\n"
+"PO-Revision-Date: 2019-07-30 01:12+0300\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: ru\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
+"%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+"X-Generator: Poedit 2.2.3\n"
+
+#: ../../../radiotray_ng.cpp:595
+msgid "(Mute)"
+msgstr "(Выкл.)"
+
+#: ../appindicator_gui.cpp:483
+msgid "About"
+msgstr "О программе"
+
+#: ../appindicator_gui.cpp:271
+msgid "Bitrate"
+msgstr "Битрейт"
+
+#: ../appindicator_gui.cpp:456
+msgid "Bookmark Editor..."
+msgstr "Редактор закладок..."
+
+#: ../../../radiotray_ng.cpp:656
+msgid "Bookmarks Reload Failed"
+msgstr "Ошибка при чтении закладок"
+
+#: ../../../radiotray_ng.cpp:647
+msgid "Bookmarks Reloaded"
+msgstr "Закладки обновлены"
+
+#: ../appindicator_gui.cpp:591
+msgid "Bookmarks changed on disk"
+msgstr "Закладки изменены на диске"
+
+#: ../../../radiotray_ng.cpp:401
+msgid "Buffering"
+msgstr "Буферизация"
+
+#: ../appindicator_gui.cpp:603
+msgid "Cancel"
+msgstr "Отмена"
+
+#: ../appindicator_gui.cpp:279
+msgid "Codec"
+msgstr "Кодек"
+
+#: ../../../radiotray_ng.cpp:393
+msgid "Connecting"
+msgstr "Соединение"
+
+#: ../../../radiotray_ng.cpp:412
+msgid "Error"
+msgstr "Ошибка"
+
+#: ../../../radiotray_ng.cpp:536
+msgid "Failed to download playlist"
+msgstr "Ошибка при загрузке плейлиста"
+
+#: ../appindicator_gui.cpp:638
+msgid "Invalid sleep timer"
+msgstr "Неверный таймер сна"
+
+#: ../appindicator_gui.cpp:611
+msgid "Minutes"
+msgstr "Минут"
+
+#: ../appindicator_gui.cpp:605
+msgid "OK"
+msgstr "OK"
+
+#: ../appindicator_gui.cpp:341
+msgid "Playing"
+msgstr "Играет"
+
+#: ../appindicator_gui.cpp:449
+msgid "Preferences"
+msgstr "Настройки"
+
+#: ../appindicator_gui.cpp:492
+msgid "Quit"
+msgstr "Выйти"
+
+#: ../appindicator_gui.cpp:461
+msgid "Reload Bookmarks"
+msgstr "Перечитать закладки"
+
+#: ../appindicator_gui.cpp:470 ../appindicator_gui.cpp:600
+msgid "Sleep Timer"
+msgstr "Таймер сна"
+
+#: ../appindicator_gui.cpp:579
+msgid "Sleep timer expired"
+msgstr "Таймер сна истёк"
+
+#: ../appindicator_gui.cpp:668
+msgid "Sleep timer stopped"
+msgstr "Таймер сна остановлен"
+
+#: ../../../radiotray_ng.cpp:542
+msgid "Station Error"
+msgstr "Ошибка станции"
+
+#: ../appindicator_gui.cpp:384 ../../../radiotray_ng.cpp:64
+msgid "Stopped"
+msgstr "Остановлено"
+
+#: ../appindicator_gui.cpp:314
+msgid "Turn Off"
+msgstr "Выключить"
+
+#: ../appindicator_gui.cpp:296
+msgid "Turn On"
+msgstr "Включить"
+
+#: ../appindicator_gui.cpp:264 ../../../radiotray_ng.cpp:589
+#: ../../../radiotray_ng.cpp:632
+msgid "Volume"
+msgstr "Громкость"
+
+#: ../appindicator_gui.cpp:421
+msgid "action"
+msgstr "действие"
+
+#: ../../../radiotray_ng.cpp:353
+msgid "kb/s"
+msgstr "кб/с"
+
+#: ../appindicator_gui.cpp:675
+msgid "minute sleep timer started"
+msgstr "минут таймер сна запущен"
+
+#: ../appindicator_gui.cpp:399
+msgid "status"
+msgstr "статус"
+
+#: ../appindicator_gui.cpp:437
+msgid "volume"
+msgstr "громкость"

--- a/src/radiotray-ng/gui/appindicator/po/src.txt
+++ b/src/radiotray-ng/gui/appindicator/po/src.txt
@@ -1,0 +1,2 @@
+../appindicator_gui.cpp
+../../../radiotray_ng.cpp

--- a/src/radiotray-ng/main.cpp
+++ b/src/radiotray-ng/main.cpp
@@ -231,21 +231,21 @@ bool process_command_line_args(int argc, char* argv[])
 
 int main(int argc, char* argv[])
 {
-    std::locale::global(std::locale(""));
+	std::locale::global(std::locale(""));
 
 #if HAVE_GETTEXT
-    const char * i18n_domain = GETTEXT_DOMAIN;
+	const char * i18n_domain = GETTEXT_DOMAIN;
 
 #ifndef NDEBUG
-    // under debug build search .mo files in cwd
-    bindtextdomain (i18n_domain, ".");
+	// under debug build search .mo files in cwd
+	bindtextdomain (i18n_domain, ".");
 #endif
 
-    bind_textdomain_codeset(i18n_domain, "UTF-8");
-    textdomain (i18n_domain);
+	bind_textdomain_codeset(i18n_domain, "UTF-8");
+	textdomain (i18n_domain);
 #endif
 
-    if (!process_command_line_args(argc, argv))
+	if (!process_command_line_args(argc, argv))
 	{
 		return 0;
 	}

--- a/src/radiotray-ng/main.cpp
+++ b/src/radiotray-ng/main.cpp
@@ -41,6 +41,7 @@
 #include <boost/log/utility/setup/file.hpp>
 #include <boost/program_options.hpp>
 
+#include <locale.h>
 
 void init_logging(std::shared_ptr<IConfig> config)
 {
@@ -230,7 +231,21 @@ bool process_command_line_args(int argc, char* argv[])
 
 int main(int argc, char* argv[])
 {
-	if (!process_command_line_args(argc, argv))
+    std::locale::global(std::locale(""));
+
+#if HAVE_GETTEXT
+    const char * i18n_domain = GETTEXT_DOMAIN;
+
+#ifndef NDEBUG
+    // under debug build search .mo files in cwd
+    bindtextdomain (i18n_domain, ".");
+#endif
+
+    bind_textdomain_codeset(i18n_domain, "UTF-8");
+    textdomain (i18n_domain);
+#endif
+
+    if (!process_command_line_args(argc, argv))
 	{
 		return 0;
 	}

--- a/src/radiotray-ng/radiotray_ng.cpp
+++ b/src/radiotray-ng/radiotray_ng.cpp
@@ -586,24 +586,24 @@ void RadiotrayNG::volume_down_msg()
 
 void RadiotrayNG::mute()
 {
-    std::string msg  = std::string(_("Volume")) + ": " + this->volume + "% ";
+	std::string msg  = std::string(_("Volume")) + ": " + this->volume + "% ";
 
-    if (!this->player->is_muted())
-    {
-        this->player->mute();
+	if (!this->player->is_muted())
+	{
+		this->player->mute();
 
-        msg += _("(Mute)");
-    }
-    else
-    {
-        this->player->unmute();
-    }
+		msg += _("(Mute)");
+	}
+	else
+	{
+		this->player->unmute();
+	}
 
-    if (this->config->get_bool(NOTIFICATION_KEY, DEFAULT_NOTIFICATION_VALUE))
-    {
-        this->notification.notify(msg, APP_NAME_DISPLAY,
-            radiotray_ng::word_expand(this->config->get_string(RADIOTRAY_NG_NOTIFICATION_KEY, DEFAULT_RADIOTRAY_NG_NOTIFICATION_VALUE)));
-    }
+	if (this->config->get_bool(NOTIFICATION_KEY, DEFAULT_NOTIFICATION_VALUE))
+	{
+		this->notification.notify(msg, APP_NAME_DISPLAY,
+			radiotray_ng::word_expand(this->config->get_string(RADIOTRAY_NG_NOTIFICATION_KEY, DEFAULT_RADIOTRAY_NG_NOTIFICATION_VALUE)));
+	}
 }
 
 
@@ -626,14 +626,14 @@ void RadiotrayNG::set_and_save_volume(uint32_t new_volume)
 
 void RadiotrayNG::display_volume_level()
 {
-    if (this->config->get_bool(NOTIFICATION_KEY, DEFAULT_NOTIFICATION_VALUE))
-    {
-        std::string volume_str =
-            std::string (_("Volume")) + ": " + std::to_string(this->config->get_uint32(VOLUME_LEVEL_KEY, DEFAULT_VOLUME_LEVEL_VALUE)) + "%";
+	if (this->config->get_bool(NOTIFICATION_KEY, DEFAULT_NOTIFICATION_VALUE))
+	{
+		std::string volume_str =
+			std::string (_("Volume")) + ": " + std::to_string(this->config->get_uint32(VOLUME_LEVEL_KEY, DEFAULT_VOLUME_LEVEL_VALUE)) + "%";
 
-        this->notification.notify(volume_str, APP_NAME_DISPLAY,
-            radiotray_ng::word_expand(this->config->get_string(RADIOTRAY_NG_NOTIFICATION_KEY, DEFAULT_RADIOTRAY_NG_NOTIFICATION_VALUE)));
-    }
+		this->notification.notify(volume_str, APP_NAME_DISPLAY,
+			radiotray_ng::word_expand(this->config->get_string(RADIOTRAY_NG_NOTIFICATION_KEY, DEFAULT_RADIOTRAY_NG_NOTIFICATION_VALUE)));
+	}
 }
 
 

--- a/src/radiotray-ng/radiotray_ng.cpp
+++ b/src/radiotray-ng/radiotray_ng.cpp
@@ -61,7 +61,7 @@ void RadiotrayNG::stop()
 	if (this->config->get_bool(NOTIFICATION_KEY, DEFAULT_NOTIFICATION_VALUE) &&
 		this->config->get_bool(NOTIFICATION_VERBOSE_KEY, DEFAULT_NOTIFICATION_VERBOSE_VALUE))
 	{
-		this->notification.notify("Stopped", this->get_station(), this->notification_image);
+		this->notification.notify(_("Stopped"), this->get_station(), this->notification_image);
 	}
 
 	this->player->stop();
@@ -350,7 +350,7 @@ void RadiotrayNG::on_tags_changed_event_processing(const IEventBus::event& /*ev*
 		{
 			if (!data[TAG_BITRATE].empty())
 			{
-				this->bitrate = std::to_string(lround(std::stoul(data[TAG_BITRATE])/1000.0)) + " kb/s";
+				this->bitrate = std::to_string(lround(std::stoul(data[TAG_BITRATE])/1000.0)) + " " + _("kb/s");
 			}
 		}
 		catch(std::invalid_argument& ex)
@@ -390,7 +390,7 @@ void RadiotrayNG::on_state_changed_event(const IEventBus::event& /*ev*/, IEventB
 		{
 			if (data[STATE_KEY] == STATE_CONNECTING)
 			{
-				this->notification.notify("Connecting", APP_NAME_DISPLAY, this->notification_image);
+				this->notification.notify(_("Connecting"), APP_NAME_DISPLAY, this->notification_image);
 				return;
 			}
 
@@ -398,7 +398,7 @@ void RadiotrayNG::on_state_changed_event(const IEventBus::event& /*ev*/, IEventB
 			{
 				const auto station = this->get_station();
 
-				this->notification.notify("Buffering", (station.empty()) ? APP_NAME_DISPLAY : station, this->notification_image);
+				this->notification.notify(_("Buffering"), (station.empty()) ? APP_NAME_DISPLAY : station, this->notification_image);
 				return;
 			}
 		}
@@ -409,7 +409,7 @@ void RadiotrayNG::on_state_changed_event(const IEventBus::event& /*ev*/, IEventB
 void RadiotrayNG::on_station_error_event(const IEventBus::event& /*ev*/, IEventBus::event_data_t& data)
 {
 	// always show errors
-	this->notification.notify("Error", data[ERROR_KEY], this->notification_image);
+	this->notification.notify(_("Error"), data[ERROR_KEY], this->notification_image);
 }
 
 
@@ -533,13 +533,13 @@ void RadiotrayNG::play(const std::string& group, const std::string& station)
 		LOG(error) << "failed to download playlist: " << std.url;
 
 		this->event_bus->publish_only(IEventBus::event::state_changed, STATE_KEY, STATE_STOPPED);
-		this->event_bus->publish_only(IEventBus::event::station_error, ERROR_KEY, "Failed to download playlist");
+		this->event_bus->publish_only(IEventBus::event::station_error, ERROR_KEY, _("Failed to download playlist"));
 	}
 	else
 	{
 		LOG(error) << "failed to read bookmark: " << group << " : " << station;
 
-		this->event_bus->publish_only(IEventBus::event::station_error, ERROR_KEY, "Station Error");
+		this->event_bus->publish_only(IEventBus::event::station_error, ERROR_KEY, _("Station Error"));
 	}
 }
 
@@ -586,13 +586,13 @@ void RadiotrayNG::volume_down_msg()
 
 void RadiotrayNG::mute()
 {
-    std::string msg{"Volume: " + this->volume + "% "};
+    std::string msg  = std::string(_("Volume")) + ": " + this->volume + "% ";
 
     if (!this->player->is_muted())
     {
         this->player->mute();
 
-        msg += "(Mute)";
+        msg += _("(Mute)");
     }
     else
     {
@@ -629,7 +629,7 @@ void RadiotrayNG::display_volume_level()
     if (this->config->get_bool(NOTIFICATION_KEY, DEFAULT_NOTIFICATION_VALUE))
     {
         std::string volume_str =
-            "Volume: " + std::to_string(this->config->get_uint32(VOLUME_LEVEL_KEY, DEFAULT_VOLUME_LEVEL_VALUE)) + "%";
+            std::string (_("Volume")) + ": " + std::to_string(this->config->get_uint32(VOLUME_LEVEL_KEY, DEFAULT_VOLUME_LEVEL_VALUE)) + "%";
 
         this->notification.notify(volume_str, APP_NAME_DISPLAY,
             radiotray_ng::word_expand(this->config->get_string(RADIOTRAY_NG_NOTIFICATION_KEY, DEFAULT_RADIOTRAY_NG_NOTIFICATION_VALUE)));
@@ -644,7 +644,7 @@ bool RadiotrayNG::reload_bookmarks()
 	if (result)
 	{
 		// always show...
-		this->notification.notify("Bookmarks Reloaded", APP_NAME_DISPLAY,
+		this->notification.notify(_("Bookmarks Reloaded"), APP_NAME_DISPLAY,
 			radiotray_ng::word_expand(this->config->get_string(RADIOTRAY_NG_NOTIFICATION_KEY, DEFAULT_RADIOTRAY_NG_NOTIFICATION_VALUE)));
 
 		// force reloading of current groups station list...
@@ -653,7 +653,7 @@ bool RadiotrayNG::reload_bookmarks()
 	else
 	{
 		// always show...
-		this->notification.notify("Bookmarks Reload Failed", APP_NAME_DISPLAY,
+		this->notification.notify(_("Bookmarks Reload Failed"), APP_NAME_DISPLAY,
 			radiotray_ng::word_expand(this->config->get_string(RADIOTRAY_NG_NOTIFICATION_KEY, DEFAULT_RADIOTRAY_NG_NOTIFICATION_VALUE)));
 	}
 


### PR DESCRIPTION
This changeset add translation for radiotray-NG (fix #53 ) (with some limitations).

Note1:
> HowTo translate to lang XXX?
> 1. download src/radiotray-ng/gui/appindicator/po/i18n.pot (current gui) and translate to $LANG.po file (you can use poEdit or other app)
> 2. send translated to owner.

Note2:
 `src/radiotray-ng/gui/appindicator/po/src.txt` - sources for i18n.pot. `i18n.pot` - source for `$LANG.po` file. `$LANG.po` - source for `$GETTEXT_DOMAIN.mo` file...
Supported langs, source `po` dir list, result `mo` filenames - in `cmake/i18n/CMakeLists.txt`

Aslo see two main make targets: `po-update` (dont forget set `UPDATE_PO` option for cmale) and `mo-update`. `po-update` - update `.pot` and `.po` files (add new lines), `mo-update` - generate results `.mo` files.

Note4: (not implemented,  not bug) `rtng-bookmark-editor` not translated -(see `wxUSE_INTL` and `WXINTL_NO_GETTEXT_MACRO`) - no time for learn wxWidgets lib right now....

Note5: for testing try (need **DEBUG** build):
```
export LANGUAGE=ru_RU

#in build directory:
./radiotray-ng

# for debug (grep .mo):
strace -o debug.log ./radiotray-ng
```

Note6: when you make debug build (NDEBUG is NOT set) .mo files will be searched in current  working directory (see: `main()` function in `src/radiotray-ng/main.cpp` for details)