### PR TITLE
Fix build with GCC13

### DIFF
--- a/include/radiotray-ng/i_config.hpp
+++ b/include/radiotray-ng/i_config.hpp
@@ -17,6 +17,7 @@
 
 #pragma once
 #include <string>
+#include <cstdint>
 
 // easier interface to work with than jsoncpp
 


### PR DESCRIPTION
Due to changes in GCC13 need fix include.
https://gcc.gnu.org/gcc-13/porting_to.html#header-dep-changes

Else this error happen
```
/builddir/build/BUILD/radiotray-ng-0.2.8/include/radiotray-ng/i_config.hpp:34:57: error: 'uint32_t' has not been declared
   34 |         virtual void set_uint32(const std::string& key, uint32_t value) = 0;
      |                                                         ^~~~~~~~
```