### PR TITLE
Update CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,7 @@ endif(CCACHE_FOUND)
 # search for libs
 find_package(CURL      REQUIRED)
 find_package(PkgConfig REQUIRED)
-find_package(Boost     REQUIRED filesystem system log program_options thread)
+find_package(Boost     REQUIRED filesystem log program_options thread)
 
 # set up wxWidgets to prefer gtk3
 execute_process(COMMAND wx-config --selected-config --toolkit=gtk3


### PR DESCRIPTION
In the latest Boost C++ Libraries (1.89.0) the Boost.System stub library is removed. This results in an error when building from source: ... CMake Error at /usr/lib/cmake/Boost-1.89.0/
...    BoostConfig.cmake:141 (find_package):
...    Could not find a package configuration file provided by "boost_system"
...    (requested version 1.89.0) with any of the following names